### PR TITLE
Update Postman OAuth Collection

### DIFF
--- a/Postman Collections/V3 API.postman_collection.json
+++ b/Postman Collections/V3 API.postman_collection.json
@@ -87,7 +87,18 @@
 							]
 						},
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://auth.eagleeyenetworks.com/oauth2/token?grant_type=authorization_code&client_id={{client_id}}&code={{code}}&redirect_uri=http://127.0.0.1:3333",
 							"protocol": "https",
@@ -100,7 +111,7 @@
 								"oauth2",
 								"token"
 							],
-							"query": [
+							"body": [
 								{
 									"key": "grant_type",
 									"value": "authorization_code"
@@ -158,7 +169,18 @@
 							]
 						},
 						"method": "POST",
-						"header": [],
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://auth.eagleeyenetworks.com/oauth2/token?grant_type=refresh_token&refresh_token={{refresh_token}}",
 							"protocol": "https",
@@ -171,7 +193,7 @@
 								"oauth2",
 								"token"
 							],
-							"query": [
+							"body": [
 								{
 									"key": "grant_type",
 									"value": "refresh_token"

--- a/Postman Collections/V3 API.postman_collection.json
+++ b/Postman Collections/V3 API.postman_collection.json
@@ -111,24 +111,27 @@
 								"oauth2",
 								"token"
 							],
-							"body": [
-								{
-									"key": "grant_type",
-									"value": "authorization_code"
-								},
-								{
-									"key": "client_id",
-									"value": "{{client_id}}"
-								},
-								{
-									"key": "code",
-									"value": "{{code}}"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "http://127.0.0.1:3333"
-								}
-							]
+							"body": {
+								"mode": "x-www-form-urlencoded",
+								"x-www-form-encoded": [
+									{
+										"key": "grant_type",
+										"value": "authorization_code"
+									},
+									{
+										"key": "client_id",
+										"value": "{{client_id}}"
+									},
+									{
+										"key": "code",
+										"value": "{{code}}"
+									},
+									{
+										"key": "redirect_uri",
+										"value": "http://127.0.0.1:3333"
+									}
+								]
+							}
 						}
 					},
 					"response": []
@@ -193,16 +196,19 @@
 								"oauth2",
 								"token"
 							],
-							"body": [
-								{
-									"key": "grant_type",
-									"value": "refresh_token"
-								},
-								{
-									"key": "refresh_token",
-									"value": "{{refresh_token}}"
-								}
-							]
+							"body": {
+								"mode": "x-www-form-urlencoded",
+								"x-www-form-encoded": [
+									{
+										"key": "grant_type",
+										"value": "refresh_token"
+									},
+									{
+										"key": "refresh_token",
+										"value": "{{refresh_token}}"
+									}
+								]
+							}
 						}
 					},
 					"response": []


### PR DESCRIPTION
Using query parameters with https://auth.eagleeyenetworks.com/oauth2/token is now deprecated. This PR updates our Postman collection to use body parameters instead.

[Changelog Update](https://developer.eagleeyenetworks.com/changelog/9172024-oauth-security)