### PR TITLE
Add Measure RTSP Latency example

### DIFF
--- a/Measure RTSP Latency/.env.example
+++ b/Measure RTSP Latency/.env.example
@@ -1,0 +1,3 @@
+EEN_CLIENT_ID=your_client_id_here
+EEN_CLIENT_SECRET=your_client_secret_here
+EEN_CAMERA_ID=your_camera_id_here

--- a/Measure RTSP Latency/.gitignore
+++ b/Measure RTSP Latency/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.env
+tokens.json
+__pycache__/
+*.pyc
+*:Zone.Identifier
+latency_snapshot.jpg
+.claude/

--- a/Measure RTSP Latency/.vscode/settings.json
+++ b/Measure RTSP Latency/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        ".",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/Measure RTSP Latency/CLAUDE.md
+++ b/Measure RTSP Latency/CLAUDE.md
@@ -1,0 +1,171 @@
+# Eagle Eye Networks OAuth Demo — Setup Guide
+
+A Python demo for the Eagle Eye Networks API v3. Authenticates via OAuth 2.0,
+lists cameras, and streams live RTSP video using GStreamer.
+
+**No pip dependencies** — the core OAuth/API code uses only the Python standard
+library. The video streaming modules (`frames_gst.py`, `measure_latency.py`)
+require GStreamer and OpenCV, detailed below.
+
+---
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in your credentials:
+
+```
+EEN_CLIENT_ID=your_client_id_here
+EEN_CLIENT_SECRET=your_client_secret_here
+EEN_CAMERA_ID=your_camera_id_here
+```
+
+Obtain credentials from the [Eagle Eye Networks Developer Portal](https://developer.eagleeyenetworks.com/).
+The redirect URI `http://127.0.0.1:3333/callback` must be registered in your app settings.
+
+---
+
+## Usage
+
+```bash
+python main.py login    # Run the full OAuth authorization flow
+python main.py cameras  # List cameras (requires prior login)
+python main.py stream   # Print the RTSP URL for the configured camera
+python main.py refresh  # Manually refresh the stored access token
+```
+
+---
+
+## Setup — Windows
+
+### Requirements
+- Windows 10/11 (64-bit)
+- Python 3.10 or newer: https://www.python.org/downloads/
+
+### Steps
+
+1. **Clone / copy the project files** into a folder, e.g. `C:\Users\you\een-demo`.
+
+2. **Create `.env`** from `.env.example`:
+   ```
+   copy .env.example .env
+   ```
+   Open `.env` in Notepad and fill in your credentials.
+
+3. **Verify Python version** (must be 3.10+):
+   ```cmd
+   python --version
+   ```
+
+4. **Run the login flow:**
+   ```cmd
+   python main.py login
+   ```
+   Your browser will open for authorization. After approving, tokens are saved to `tokens.json`.
+
+5. **List cameras:**
+   ```cmd
+   python main.py cameras
+   ```
+
+### Video streaming on Windows (optional)
+
+`frames_gst.py` and `measure_latency.py` require GStreamer and OpenCV.
+The easiest path on Windows is to use WSL2 (see Linux section below),
+since GStreamer is much simpler to install there.
+
+If you want native Windows support:
+
+1. Install [GStreamer 1.24+ runtime + development](https://gstreamer.freedesktop.org/download/#windows)
+   — choose the **MSVC 64-bit** installer. Install **both** the Runtime and Development packages.
+
+2. Add GStreamer to your PATH (the installer can do this automatically):
+   ```
+   C:\gstreamer\1.0\msvc_x86_64\bin
+   ```
+
+3. Install Python bindings and OpenCV:
+   ```cmd
+   pip install PyGObject opencv-python numpy
+   ```
+
+---
+
+## Virtual Environment
+
+The `.venv` directory is excluded from version control. Recreate it with:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate        # Linux / WSL2
+# .venv\Scripts\activate         # Windows (cmd/PowerShell)
+pip install opencv-python-headless numpy
+```
+
+> On WSL2 with a display, use `opencv-python` instead of `opencv-python-headless`.
+
+---
+
+## Setup — Linux / WSL2
+
+### Requirements
+- Python 3.10+
+- GStreamer 1.0 (for video streaming)
+
+### Steps
+
+1. **Clone / copy the project files.**
+
+2. **Create `.env`** from `.env.example`:
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env` and fill in your credentials.
+
+3. **Verify Python version** (must be 3.10+):
+   ```bash
+   python3 --version
+   ```
+
+4. **Install GStreamer system packages** (required for `frames_gst.py`):
+   ```bash
+   sudo apt update
+   sudo apt install -y \
+       python3-gi python3-gi-cairo gir1.2-gst-plugins-base-1.0 \
+       gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+       gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+       gstreamer1.0-rtsp gstreamer1.0-tools \
+       libgstreamer1.0-dev
+   ```
+
+5. **Install OpenCV and NumPy** (required for frame display and saving):
+   ```bash
+   pip install opencv-python numpy
+   ```
+   > On WSL2 without a display, use `opencv-python-headless` instead:
+   > ```bash
+   > pip install opencv-python-headless numpy
+   > ```
+
+6. **Run the login flow:**
+   ```bash
+   python3 main.py login
+   ```
+   Your browser will open for authorization. After approving, tokens are saved to `tokens.json`.
+
+7. **List cameras:**
+   ```bash
+   python3 main.py cameras
+   ```
+
+8. **Measure stream latency** (requires GStreamer + OpenCV):
+   ```bash
+   python3 measure_latency.py
+   ```
+
+### WSL2 notes
+
+- The OAuth callback server listens on `127.0.0.1:3333`. If your browser is on Windows,
+  the callback will reach WSL2 automatically via the WSL2 localhost proxy (Windows 11 / WSL2 0.67+).
+  On older setups you may need to run the login step from a Windows terminal instead.
+- Live display via `cv2.imshow` requires an X11 server (e.g. VcXsrv, X410) and
+  `export DISPLAY=:0` set in your shell. For headless use, `opencv-python-headless` is sufficient.

--- a/Measure RTSP Latency/PROJECT.md
+++ b/Measure RTSP Latency/PROJECT.md
@@ -1,0 +1,110 @@
+# What This Project Does
+
+This project is a minimal Python client for the **Eagle Eye Networks (EEN) API v3**. It demonstrates how to authenticate with Eagle Eye's cloud platform, interact with its REST API, and pull live video streams from IP cameras.
+
+---
+
+## Overview
+
+Eagle Eye Networks is a cloud-based video surveillance platform. Cameras connect to EEN's cloud, which exposes an API for listing devices, retrieving live streams, and more. This project covers three areas:
+
+1. **OAuth 2.0 login** — authenticates a user account and stores access tokens locally
+2. **REST API calls** — lists cameras and resolves account-specific API endpoints
+3. **Live RTSP streaming** — decodes and measures latency of live camera video via GStreamer
+
+---
+
+## Files and What They Do
+
+| File | Purpose |
+|---|---|
+| `main.py` | CLI entry point — `login`, `cameras`, `stream`, `refresh` commands |
+| `auth.py` | OAuth 2.0 token exchange, refresh, and local storage |
+| `api.py` | Thin HTTP client wrapping EEN API v3 endpoints |
+| `config.py` | Loads credentials from `.env` and defines constants |
+| `callback_server.py` | Temporary local HTTP server that captures the OAuth redirect |
+| `frames_gst.py` | GStreamer-based RTSP frame decoder with timing support |
+| `measure_latency.py` | Measures true camera-to-receipt latency using RTCP NTP timestamps |
+
+---
+
+## How Authentication Works
+
+Eagle Eye uses the **OAuth 2.0 Authorization Code** flow:
+
+1. `main.py login` builds an authorization URL and opens it in the browser
+2. The user logs in on Eagle Eye's website and approves the app
+3. Eagle Eye redirects to `http://127.0.0.1:3333/callback?code=...`
+4. `callback_server.py` captures that redirect on a local HTTP server
+5. `auth.py` exchanges the code for an **access token** and **refresh token**, saved to `tokens.json`
+6. On subsequent runs, `auth.py` automatically refreshes the access token when it expires (within a 5-minute buffer)
+
+---
+
+## How API Calls Work
+
+Eagle Eye's API uses **account-specific base URLs** (e.g. `https://api.c012.eagleeyenetworks.com/api/v3.0`). `api.py` resolves this on the first call by hitting the global `/clientSettings` endpoint, then caches it for the session.
+
+All requests attach a `Bearer` token from `tokens.json`. If the token is expired, `auth.py` refreshes it transparently before the request goes out.
+
+---
+
+## How Video Streaming Works
+
+`frames_gst.py` builds a **GStreamer pipeline** that connects to an RTSP URL returned by the API:
+
+```
+rtspsrc → decodebin → videoconvert → appsink
+```
+
+It exposes three generators:
+
+- `iter_frames(url)` — yields raw BGR frames as NumPy arrays
+- `iter_frames_timed(url)` — yields frames with PTS-based latency estimates
+- `iter_frames_ntp(url)` — yields frames with true NTP wall-clock capture times from RTCP Sender Reports
+
+`cv2.imshow` / `cv2.imwrite` are used only for display and saving snapshots — all decoding goes through GStreamer.
+
+---
+
+## Latency Measurement
+
+`measure_latency.py` uses `iter_frames_ntp` to compute true **camera-capture-to-local-receipt** latency:
+
+- Waits for the first **RTCP Sender Report** (carries the camera's NTP clock)
+- Compares the NTP capture timestamp on each frame against `time.time()` at receipt
+- Prints per-frame latency in milliseconds and a min/max/avg summary after 10 frames
+- Saves a snapshot of the last frame to `latency_snapshot.jpg`
+
+---
+
+## Data Flow Diagram
+
+```
+  Browser
+     |
+     | (1) User logs in at Eagle Eye
+     v
+Eagle Eye Auth Server
+     |
+     | (2) Redirects to localhost:3333/callback?code=...
+     v
+callback_server.py  ──► auth.py  ──► tokens.json
+                                          |
+                             (3) Bearer token on every request
+                                          |
+                                          v
+                                   api.py ──► EEN REST API v3
+                                                    |
+                                        (4) Returns RTSP URL
+                                                    |
+                                                    v
+                                            frames_gst.py
+                                         (GStreamer pipeline)
+                                                    |
+                                        (5) Decoded BGR frames
+                                                    |
+                                                    v
+                                         measure_latency.py
+                                          cv2.imshow / imwrite
+```

--- a/Measure RTSP Latency/api.py
+++ b/Measure RTSP Latency/api.py
@@ -1,0 +1,94 @@
+"""
+Minimal Eagle Eye Networks API v3 client.
+Handles base-URL discovery and authenticated requests.
+"""
+import json
+import urllib.parse
+import urllib.request
+
+import auth
+import config
+
+
+# Base URL is account-specific and must be resolved before making API calls.
+_base_url: str | None = None
+
+
+def _get_json(url: str, headers: dict, params: dict | None = None) -> dict:
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _get_base_url(access_token: str) -> str:
+    """
+    Fetch the account-specific base URL from the client settings endpoint.
+    Eagle Eye's base URL looks like https://api.c000.eagleeyenetworks.com/api/v3.0
+    """
+    global _base_url
+    if _base_url:
+        return _base_url
+
+    data = _get_json(
+        "https://api.eagleeyenetworks.com/api/v3.0/clientSettings",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        },
+    )
+    https_base = data.get("httpsBaseUrl", {})
+    hostname = https_base.get("hostname", "api.eagleeyenetworks.com")
+    port = https_base.get("port", 443)
+    _base_url = f"https://{hostname}:{port}/api/v3.0"
+    return _base_url
+
+
+def get_live_stream(camera_id: str | None = None, stream_type: str = "main", local: bool = False) -> str:
+    """
+    Return an RTSP URL for a live camera stream.
+
+    Args:
+        camera_id:   Camera device ID. Defaults to CAMERA_ID from config.
+        stream_type: "main" (full resolution) or "preview" (low quality).
+        local:       If True, request the local bridge RTSP URL instead of the cloud URL.
+
+    Returns:
+        The RTSP URL with the access token appended.
+    """
+    device_id = camera_id or config.CAMERA_ID
+    if not device_id:
+        raise ValueError("No camera ID provided. Set EEN_CAMERA_ID in .env or pass camera_id.")
+
+    include = "localRtspUrl" if local else "rtspUrl"
+    result = get("/feeds", params={"deviceId": device_id, "type": stream_type, "include": include})
+    feeds = result.get("results", [])
+    if not feeds:
+        raise RuntimeError(f"No feed returned for camera {device_id}.")
+
+    access_token = auth.get_valid_access_token()
+    rtsp_url = feeds[0].get(include)
+    if not rtsp_url:
+        raise RuntimeError(f"Response did not contain '{include}' for camera {device_id}.")
+
+    return f"{rtsp_url}&access_token={access_token}"
+
+
+def get(endpoint: str, params: dict | None = None) -> dict:
+    """
+    Perform a GET request against the EEN API v3.
+    Automatically resolves the base URL and handles token refresh.
+    """
+    access_token = auth.get_valid_access_token()
+    base_url = _get_base_url(access_token)
+
+    url = f"{base_url}{endpoint}"
+    return _get_json(
+        url,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        },
+        params=params,
+    )

--- a/Measure RTSP Latency/auth.py
+++ b/Measure RTSP Latency/auth.py
@@ -1,0 +1,107 @@
+import base64
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import config
+
+
+def build_authorization_url() -> str:
+    """Construct the authorization URL to redirect the user to."""
+    params = {
+        "client_id": config.CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": config.REDIRECT_URI,
+        "scope": config.SCOPE,
+    }
+    return f"{config.AUTH_URL}?{urllib.parse.urlencode(params)}"
+
+
+def _basic_auth_header() -> str:
+    """Return the Base64-encoded Basic Auth header value."""
+    credentials = f"{config.CLIENT_ID}:{config.CLIENT_SECRET}"
+    encoded = base64.b64encode(credentials.encode()).decode()
+    return f"Basic {encoded}"
+
+
+def _post(url: str, headers: dict, data: dict) -> dict:
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def exchange_code_for_tokens(code: str) -> dict:
+    """Exchange an authorization code for access + refresh tokens."""
+    headers = {
+        "Authorization": _basic_auth_header(),
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": config.REDIRECT_URI,
+        "scope": config.SCOPE,
+    }
+    tokens = _post(config.TOKEN_URL, headers, data)
+    tokens["obtained_at"] = time.time()
+    return tokens
+
+
+def refresh_access_token(refresh_token: str) -> dict:
+    """Use a refresh token to obtain a new access token."""
+    headers = {
+        "Authorization": _basic_auth_header(),
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    tokens = _post(config.TOKEN_URL, headers, data)
+    tokens["obtained_at"] = time.time()
+    return tokens
+
+
+def save_tokens(tokens: dict) -> None:
+    """Persist tokens to a local JSON file."""
+    with open(config.TOKEN_FILE, "w") as f:
+        json.dump(tokens, f, indent=2)
+    print(f"Tokens saved to {config.TOKEN_FILE}")
+
+
+def load_tokens() -> dict | None:
+    """Load tokens from the local JSON file. Returns None if not found."""
+    try:
+        with open(config.TOKEN_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+
+def is_access_token_expired(tokens: dict, buffer_seconds: int = 300) -> bool:
+    """Return True if the access token is expired (or expires within buffer_seconds)."""
+    obtained_at = tokens.get("obtained_at", 0)
+    expires_in = tokens.get("expires_in", 0)
+    return time.time() >= obtained_at + expires_in - buffer_seconds
+
+
+def get_valid_access_token() -> str:
+    """
+    Return a valid access token, refreshing automatically if needed.
+    Raises RuntimeError if no tokens are stored.
+    """
+    tokens = load_tokens()
+    if tokens is None:
+        raise RuntimeError("No tokens found. Run the OAuth flow first (python main.py login).")
+
+    if is_access_token_expired(tokens):
+        print("Access token expired — refreshing...")
+        tokens = refresh_access_token(tokens["refresh_token"])
+        save_tokens(tokens)
+
+    return tokens["access_token"]

--- a/Measure RTSP Latency/callback_server.py
+++ b/Measure RTSP Latency/callback_server.py
@@ -1,0 +1,64 @@
+"""
+A minimal local HTTP server that captures the OAuth callback code.
+Starts on 127.0.0.1:CALLBACK_PORT, waits for one request, then shuts down.
+"""
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import config
+
+
+_auth_code: str | None = None
+_server_error: str | None = None
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        global _auth_code, _server_error
+
+        parsed = urllib.parse.urlparse(self.path)
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+
+        if "error" in params:
+            _server_error = params["error"]
+            self._respond(400, f"Authorization failed: {params['error']}")
+        elif "code" in params:
+            _auth_code = params["code"]
+            self._respond(200, "Authorization successful! You can close this tab.")
+        else:
+            _server_error = "No code received"
+            self._respond(400, "Unexpected callback — no code parameter.")
+
+        # Signal the server to stop after this request
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+    def _respond(self, status: int, message: str):
+        body = message.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        # Suppress default request logging
+        pass
+
+
+def wait_for_callback() -> str:
+    """
+    Start the local server and block until the OAuth callback arrives.
+    Returns the authorization code.
+    Raises RuntimeError on error or if no code is received.
+    """
+    server = HTTPServer(("127.0.0.1", config.CALLBACK_PORT), _CallbackHandler)
+    print(f"Waiting for OAuth callback on http://127.0.0.1:{config.CALLBACK_PORT}/callback ...")
+    server.serve_forever()  # Blocks until _CallbackHandler calls shutdown()
+
+    if _server_error:
+        raise RuntimeError(f"OAuth error from server: {_server_error}")
+    if not _auth_code:
+        raise RuntimeError("No authorization code received.")
+
+    return _auth_code

--- a/Measure RTSP Latency/config.py
+++ b/Measure RTSP Latency/config.py
@@ -1,0 +1,43 @@
+import os
+
+
+def _load_env(path: str = ".env") -> None:
+    """Load key=value pairs from a .env file into os.environ (does not overwrite)."""
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip().strip('"').strip("'")
+                os.environ.setdefault(key, value)
+    except FileNotFoundError:
+        pass
+
+
+_load_env()
+
+# OAuth endpoints
+AUTH_URL = "https://auth.eagleeyenetworks.com/oauth2/authorize"
+TOKEN_URL = "https://auth.eagleeyenetworks.com/oauth2/token"
+
+# Your app credentials — set these in .env
+CLIENT_ID = os.getenv("EEN_CLIENT_ID", "")
+CLIENT_SECRET = os.getenv("EEN_CLIENT_SECRET", "")
+
+# Redirect URI — must be registered in your app settings
+REDIRECT_URI = "http://127.0.0.1:3333/callback"
+
+# Scopes — vms.all grants full VMS access
+SCOPE = "vms.all"
+
+# Local callback server port
+CALLBACK_PORT = 3333
+
+# Token storage file
+TOKEN_FILE = "tokens.json"
+
+# Camera ID to use for stream requests
+CAMERA_ID = "10070d06"

--- a/Measure RTSP Latency/frames_gst.py
+++ b/Measure RTSP Latency/frames_gst.py
@@ -1,0 +1,302 @@
+"""
+RTSP frame decoder using GStreamer.
+Connects to the camera's live stream and yields frames as numpy arrays.
+
+cv2 is used only for display (imshow) and saving (imwrite).
+All stream decoding goes through GStreamer pipelines.
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Callable
+
+import gi
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
+
+import cv2
+import numpy as np
+
+Gst.init(None)
+
+_NS = Gst.SECOND  # nanoseconds per second (1_000_000_000)
+
+
+# ---------------------------------------------------------------------------
+# Timing dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FrameTiming:
+    """Timing information for a single decoded frame."""
+    stream_pos_ms: float    # PTS from the stream — ms since the pipeline started
+    received_at: float      # wall-clock time (time.time()) when frame was pulled
+    stream_opened_at: float # wall-clock time when the pipeline started playing
+
+    @property
+    def estimated_capture_time(self) -> float:
+        """Best-effort wall-clock time the frame was generated at the camera."""
+        return self.stream_opened_at + self.stream_pos_ms / 1000.0
+
+    @property
+    def latency_ms(self) -> float:
+        """Milliseconds between estimated frame capture and local receipt."""
+        return (self.received_at - self.estimated_capture_time) * 1000.0
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _build_pipeline(rtsp_url: str, ntp_sync: bool = False) -> Gst.Pipeline:
+    ntp_opts = "ntp-sync=true" if ntp_sync else ""
+    desc = (
+        f'rtspsrc location="{rtsp_url}" protocols=tcp latency=0 {ntp_opts} '
+        f'! decodebin '
+        f'! videoconvert '
+        f'! video/x-raw,format=BGR '
+        f'! appsink name=sink emit-signals=false sync=false'
+    )
+    return Gst.parse_launch(desc)
+
+
+def _pull_bgr(
+    sink: Gst.Element, dims: list
+) -> tuple[np.ndarray | None, int]:
+    """
+    Pull one sample from an appsink element.
+
+    Returns (frame, pts_ns). (None, CLOCK_TIME_NONE) = end-of-stream.
+    (None, pts_ns) with pts_ns != CLOCK_TIME_NONE = transient failure, skip.
+    """
+    sample = sink.emit("pull-sample")
+    if sample is None:
+        return None, Gst.CLOCK_TIME_NONE
+
+    buf = sample.get_buffer()
+    pts_ns = buf.pts
+
+    if dims[0] is None:
+        s = sample.get_caps().get_structure(0)
+        dims[0] = s.get_value("width")
+        dims[1] = s.get_value("height")
+
+    try:
+        ok, mi = buf.map(Gst.MapFlags.READ)
+    except (ValueError, TypeError):
+        return None, pts_ns
+    if not ok:
+        return None, pts_ns
+    try:
+        frame = np.frombuffer(mi.data, np.uint8).reshape((dims[1], dims[0], 3)).copy()
+    finally:
+        buf.unmap(mi)
+
+    return frame, pts_ns
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def iter_frames(
+    rtsp_url: str,
+    on_frame: Callable[[np.ndarray, int], bool] | None = None,
+) -> Generator[np.ndarray, None, None]:
+    """
+    Connect to an RTSP stream and yield decoded frames as BGR numpy arrays.
+
+    Args:
+        rtsp_url: Full RTSP URL (including access_token param).
+        on_frame: Optional callback(frame, frame_number) -> bool.
+                  Return False from the callback to stop iteration.
+
+    Yields:
+        numpy.ndarray: BGR image frames, shape (H, W, 3).
+    """
+    pipeline = _build_pipeline(rtsp_url)
+    pipeline.set_state(Gst.State.PLAYING)
+    sink = pipeline.get_by_name("sink")
+    dims: list = [None, None]
+    frame_number = 0
+
+    try:
+        while True:
+            frame, pts_ns = _pull_bgr(sink, dims)
+            if frame is None:
+                if pts_ns == Gst.CLOCK_TIME_NONE:
+                    break
+                continue
+            frame_number += 1
+            if on_frame is not None and on_frame(frame, frame_number) is False:
+                break
+            yield frame
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+
+
+def iter_frames_timed(
+    rtsp_url: str,
+) -> Generator[tuple[np.ndarray, FrameTiming], None, None]:
+    """
+    Like iter_frames, but yields (frame, FrameTiming) pairs.
+
+    Yields:
+        (numpy.ndarray, FrameTiming): BGR frame and its timing metadata.
+    """
+    pipeline = _build_pipeline(rtsp_url)
+    pipeline.set_state(Gst.State.PLAYING)
+    sink = pipeline.get_by_name("sink")
+    dims: list = [None, None]
+    stream_opened_at = time.time()
+
+    try:
+        while True:
+            frame, pts_ns = _pull_bgr(sink, dims)
+            received_at = time.time()
+            if frame is None:
+                if pts_ns == Gst.CLOCK_TIME_NONE:
+                    break
+                continue
+            timing = FrameTiming(
+                stream_pos_ms=pts_ns / 1e6 if pts_ns != Gst.CLOCK_TIME_NONE else 0.0,
+                received_at=received_at,
+                stream_opened_at=stream_opened_at,
+            )
+            yield frame, timing
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+
+
+def _ntp_capture_unix(
+    buf: Gst.Buffer,
+    pts_ns: int,
+    pipeline: Gst.Pipeline,
+    ntp_caps: "Gst.Caps",
+    ntp_unix_delta: int,
+) -> float | None:
+    """Return Unix capture timestamp from NTP metadata, or None if not yet available."""
+    try:
+        meta = buf.get_reference_timestamp_meta(ntp_caps)
+        if meta is not None:
+            return meta.timestamp / _NS - ntp_unix_delta
+    except Exception:
+        pass
+    if pts_ns not in (0, Gst.CLOCK_TIME_NONE):
+        base_time = pipeline.get_base_time()
+        if base_time not in (0, Gst.CLOCK_TIME_NONE):
+            candidate = (pts_ns + base_time) / _NS
+            if candidate > 946_684_800:
+                return candidate
+    return None
+
+
+def iter_frames_ntp(
+    rtsp_url: str,
+) -> Generator[tuple[np.ndarray, float | None, float], None, None]:
+    """
+    Yield (frame, capture_unix, received_at) using true NTP wall-clock time.
+
+    Sets ntp-sync=True and add-reference-timestamp-meta=True on the internal
+    rtpbin via the rtspsrc new-manager signal.
+
+    capture_unix is derived from GstReferenceTimestampMeta on the buffer when
+    available (most reliable), or falls back to (pts_ns + base_time) / 1e9
+    once GStreamer has NTP-calibrated the pipeline clock.
+
+    capture_unix is None until the first RTCP SR arrives.
+
+    Yields:
+        (frame, capture_unix, received_at)
+        - frame:        BGR numpy array (H, W, 3)
+        - capture_unix: Unix timestamp of camera capture, or None if no SR yet.
+        - received_at:  time.time() when the frame was decoded locally.
+    """
+    _NTP_UNIX_DELTA = 2_208_988_800  # seconds: NTP epoch (1900) → Unix epoch (1970)
+
+    desc = (
+        f'rtspsrc name=src location="{rtsp_url}" protocols=tcp latency=0 '
+        f'! decodebin ! videoconvert ! video/x-raw,format=BGR '
+        f'! appsink name=sink emit-signals=false sync=false'
+    )
+    pipeline = Gst.parse_launch(desc)
+    src = pipeline.get_by_name("src")
+    _ntp_caps = Gst.Caps.from_string("timestamp/x-ntp")
+
+    def _on_new_manager(rtspsrc, manager):
+        for prop in ("ntp-sync", "add-reference-timestamp-meta"):
+            try:
+                manager.set_property(prop, True)
+            except Exception:
+                pass
+
+    src.connect("new-manager", _on_new_manager)
+    pipeline.set_state(Gst.State.PLAYING)
+    sink = pipeline.get_by_name("sink")
+    dims: list = [None, None]
+
+    try:
+        while True:
+            sample = sink.emit("pull-sample")
+            if sample is None:
+                break
+
+            buf = sample.get_buffer()
+            pts_ns = buf.pts
+            received_at = time.time()
+
+            if dims[0] is None:
+                s = sample.get_caps().get_structure(0)
+                dims[0] = s.get_value("width")
+                dims[1] = s.get_value("height")
+
+            try:
+                ok, mi = buf.map(Gst.MapFlags.READ)
+            except (ValueError, TypeError):
+                continue
+            if not ok:
+                continue
+            try:
+                frame = np.frombuffer(mi.data, np.uint8).reshape((dims[1], dims[0], 3)).copy()
+            finally:
+                buf.unmap(mi)
+
+            yield frame, _ntp_capture_unix(buf, pts_ns, pipeline, _ntp_caps, _NTP_UNIX_DELTA), received_at
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+
+
+def display(rtsp_url: str, window_title: str = "EEN Live Stream") -> None:
+    """
+    Open an OpenCV window and display the live stream until 'q' is pressed.
+
+    Args:
+        rtsp_url:     Full RTSP URL (including access_token param).
+        window_title: Title of the display window.
+    """
+    print("Press 'q' in the window to quit.")
+    for frame in iter_frames(rtsp_url):
+        cv2.imshow(window_title, frame)
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            break
+    cv2.destroyAllWindows()
+
+
+def save_snapshot(rtsp_url: str, output_path: str = "snapshot.jpg") -> str:
+    """
+    Grab a single frame from the stream and save it as an image file.
+
+    Args:
+        rtsp_url:    Full RTSP URL (including access_token param).
+        output_path: File path to write (JPEG, PNG, etc. — inferred from extension).
+
+    Returns:
+        The output_path that was written.
+    """
+    for frame in iter_frames(rtsp_url):
+        cv2.imwrite(output_path, frame)
+        print(f"Snapshot saved to {output_path}")
+        return output_path
+    raise RuntimeError("No frame received from stream.")

--- a/Measure RTSP Latency/main.py
+++ b/Measure RTSP Latency/main.py
@@ -1,0 +1,108 @@
+"""
+Eagle Eye Networks OAuth 2.0 Demo
+----------------------------------
+Usage:
+  python main.py login    — Run the full OAuth authorization flow
+  python main.py cameras  — List cameras (requires prior login)
+  python main.py refresh  — Manually refresh the access token
+"""
+import sys
+import webbrowser
+
+import auth
+import api
+import config
+
+
+def cmd_login():
+    """Open browser for authorization, capture callback, exchange for tokens."""
+    if not config.CLIENT_ID or not config.CLIENT_SECRET:
+        print("ERROR: EEN_CLIENT_ID and EEN_CLIENT_SECRET must be set in your .env file.")
+        sys.exit(1)
+
+    # Step 1 — Build authorization URL and open in browser
+    auth_url = auth.build_authorization_url()
+    print(f"\nAuthorization URL:\n{auth_url}\n")
+    opened = webbrowser.open(auth_url)
+    if opened:
+        print("Browser opened. Complete authorization there.")
+    else:
+        print("Could not open browser automatically (common in WSL2).")
+        print("Copy the URL above and open it in your browser, then return here.")
+
+    # Step 2 — Start local server, block until callback arrives
+    import callback_server
+    code = callback_server.wait_for_callback()
+    print(f"Received authorization code: {code[:10]}...")
+
+    # Step 3 — Exchange code for tokens
+    print("Exchanging authorization code for tokens...")
+    tokens = auth.exchange_code_for_tokens(code)
+    auth.save_tokens(tokens)
+
+    print("\nLogin successful!")
+    print(f"  Access token expires in: {tokens.get('expires_in', '?')}s")
+    print(f"  Token type: {tokens.get('token_type', '?')}")
+
+
+def cmd_cameras():
+    """Fetch and display a list of cameras."""
+    print("Fetching cameras...")
+    try:
+        result = api.get("/cameras", params={"pageSize": 10})
+        cameras = result.get("results", [])
+        if not cameras:
+            print("No cameras found.")
+            return
+        print(f"\nFound {len(cameras)} camera(s):\n")
+        for cam in cameras:
+            print(f"  [{cam.get('id', '?')}] {cam.get('name', 'Unnamed')} — {cam.get('status', {}).get('connectionStatus', '?')}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def cmd_stream():
+    """Print the RTSP live stream URL for the configured camera."""
+    import config as cfg
+    camera_id = cfg.CAMERA_ID
+    if not camera_id:
+        print("ERROR: EEN_CAMERA_ID must be set in your .env file.")
+        sys.exit(1)
+
+    try:
+        url = api.get_live_stream()
+        print(f"\nLive stream URL for camera {camera_id}:\n{url}\n")
+        print("Open this URL in VLC or ffplay:")
+        print(f"  vlc \"{url}\"")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def cmd_refresh():
+    """Manually refresh the access token using the stored refresh token."""
+    tokens = auth.load_tokens()
+    if not tokens:
+        print("No tokens stored. Run 'python main.py login' first.")
+        sys.exit(1)
+
+    print("Refreshing access token...")
+    new_tokens = auth.refresh_access_token(tokens["refresh_token"])
+    auth.save_tokens(new_tokens)
+    print("Token refreshed successfully.")
+    print(f"  New access token expires in: {new_tokens.get('expires_in', '?')}s")
+
+
+COMMANDS = {
+    "login": cmd_login,
+    "cameras": cmd_cameras,
+    "stream": cmd_stream,
+    "refresh": cmd_refresh,
+}
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "login"
+    if cmd not in COMMANDS:
+        print(f"Unknown command: {cmd}")
+        print(f"Available commands: {', '.join(COMMANDS)}")
+        sys.exit(1)
+    COMMANDS[cmd]()

--- a/Measure RTSP Latency/measure_latency.py
+++ b/Measure RTSP Latency/measure_latency.py
@@ -1,0 +1,39 @@
+"""
+Measures true camera-to-receipt latency using RTCP Sender Report NTP timestamps.
+Run from WSL2 with the venv active:
+    python measure_latency.py
+"""
+import time
+import api
+import frames_gst
+import cv2
+
+SAMPLE_FRAMES = 10
+
+print("Fetching RTSP URL...")
+rtsp_url = api.get_live_stream()
+print("Stream ready. Waiting for RTCP Sender Report (NTP timestamps)...\n")
+
+latencies = []
+last_frame = None
+
+for frame, capture_unix, received_at in frames_gst.iter_frames_ntp(rtsp_url):
+    if capture_unix is None:
+        print("  (waiting for RTCP SR...)")
+        continue
+
+    latency_ms = (received_at - capture_unix) * 1000
+    latencies.append(latency_ms)
+    last_frame = frame
+    print(f"  Frame {len(latencies):3d} | capture {capture_unix:.3f} | latency {latency_ms:.1f} ms")
+
+    if len(latencies) >= SAMPLE_FRAMES:
+        break
+
+cv2.imwrite("latency_snapshot.jpg", last_frame)
+
+print(f"\n--- Summary ({len(latencies)} frames) ---")
+print(f"  Min latency : {min(latencies):.1f} ms")
+print(f"  Max latency : {max(latencies):.1f} ms")
+print(f"  Avg latency : {sum(latencies)/len(latencies):.1f} ms")
+print("  Snapshot    : latency_snapshot.jpg")


### PR DESCRIPTION
Python demo that connects to an EEN camera via OAuth 2.0, decodes the RTSP stream with GStreamer, and measures camera-to-receipt latency using RTCP Sender Report NTP timestamps.