### PR TITLE
CODEOWNERS: owning team Direct to Cloud (500)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Direct to Cloud (500).
+* @EENCloud/direct-to-cloud-500


### PR DESCRIPTION
Ensures **VMS-Developer-Portal** has a CODEOWNERS file naming its owning team **Direct to Cloud (500)** (`@EENCloud/direct-to-cloud-500`).

**Changes:** create .github/CODEOWNERS (@EENCloud/direct-to-cloud-500)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
